### PR TITLE
Turn off underscore dangle

### DIFF
--- a/rules/lyvly.js
+++ b/rules/lyvly.js
@@ -9,6 +9,9 @@ module.exports = {
     "no-param-reassign": [2, { props: false }],
 
     // No new classes without assigning them to a variable.
-    "no-new": 0
+    "no-new": 0,
+
+    // Allow using e.g. _id variable names
+    "no-underscore-dangle": "off"
   }
 };


### PR DESCRIPTION
### Change Description

We found in the boilerplate service we were using _id and didnt fancy scattering //eslint-disable-next-line  everywhere

### All Changes:

* [ ] Code adheres to the Lyvly code style guide
* [ ] Unit and integration tests written for new functionality
* [ ] Code is immediately deployable
* [ ] Work has been demonstrated to stakeholders
